### PR TITLE
fix #29 - Add `scope`

### DIFF
--- a/app/Kwality.UVault.Auth0/Kwality.UVault.Auth0.csproj
+++ b/app/Kwality.UVault.Auth0/Kwality.UVault.Auth0.csproj
@@ -9,7 +9,7 @@
   <!-- NuGet (Package) information. -->
   <PropertyGroup>
     <PackageId>Kwality.UVault.Auth0</PackageId>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet-essentials/Kwality.UVault</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/app/Kwality.UVault.Auth0/Models/Management.Token.cs
+++ b/app/Kwality.UVault.Auth0/Models/Management.Token.cs
@@ -38,6 +38,7 @@ public sealed class ApiManagementToken
     {
         this.issuedTimeStamp = DateTime.Now;
         this.TokenType = string.Empty;
+        this.Scope = string.Empty;
     }
 
     [JsonPropertyName("access_token")]
@@ -61,6 +62,16 @@ public sealed class ApiManagementToken
     // ReSharper disable once MemberCanBeInternal
     [JsonPropertyName("token_type")]
     public string TokenType
+    {
+        get;
+
+        [UsedImplicitly]
+        set;
+    }
+
+    // ReSharper disable once MemberCanBeInternal
+    [JsonPropertyName("scope")]
+    public string Scope
     {
         get;
 

--- a/app/Kwality.UVault.QA/M2M/Application.Token.Management.Auth0.Tests.cs
+++ b/app/Kwality.UVault.QA/M2M/Application.Token.Management.Auth0.Tests.cs
@@ -78,6 +78,9 @@ public sealed class ApplicationTokenManagementAuth0Tests
         result.Token.Should()
               .NotBeNullOrWhiteSpace();
 
+        result.Scope.Should()
+              .NotBeNullOrWhiteSpace();
+
         result.TokenType.Should()
               .Be("Bearer");
 
@@ -180,11 +183,12 @@ public sealed class ApplicationTokenManagementAuth0Tests
         {
         }
 
-        public TokenModel(string? token, string tokenType, int expiresIn)
+        public TokenModel(string? token, string tokenType, int expiresIn, string scope)
         {
             this.Token = token;
             this.TokenType = tokenType;
             this.ExpiresIn = expiresIn;
+            this.Scope = scope;
         }
     }
 
@@ -193,7 +197,7 @@ public sealed class ApplicationTokenManagementAuth0Tests
     {
         public TokenModel Map(ApiManagementToken token)
         {
-            return new TokenModel(token.AccessToken, token.TokenType, token.ExpiresIn);
+            return new TokenModel(token.AccessToken, token.TokenType, token.ExpiresIn, token.Scope);
         }
     }
 }

--- a/app/Kwality.UVault.QA/M2M/Application.Token.Management.Default.Tests.cs
+++ b/app/Kwality.UVault.QA/M2M/Application.Token.Management.Default.Tests.cs
@@ -57,6 +57,9 @@ public sealed class ApplicationTokenManagementDefaultTests
         result.Token.Should()
               .NotBeNullOrWhiteSpace();
 
+        result.Scope.Should()
+              .BeEmpty();
+
         result.ExpiresIn.Should()
               .Be(86400);
 

--- a/app/Kwality.UVault.QA/M2M/Application.Token.Management.Tests.cs
+++ b/app/Kwality.UVault.QA/M2M/Application.Token.Management.Tests.cs
@@ -102,6 +102,9 @@ public sealed class ApplicationTokenManagementTests
         result.Token.Should()
               .NotBeNullOrWhiteSpace();
 
+        result.Scope.Should()
+              .Be("read, write, update, delete");
+
         result.ExpiresIn.Should()
               .Be(86400);
 
@@ -118,8 +121,8 @@ public sealed class ApplicationTokenManagementTests
         {
         }
 
-        public Model(string token, int expiresIn, string tokenType)
-            : base(token, expiresIn, tokenType)
+        public Model(string token, int expiresIn, string tokenType, string scope)
+            : base(token, expiresIn, tokenType, scope)
         {
         }
     }
@@ -135,7 +138,7 @@ public sealed class ApplicationTokenManagementTests
             return Task.FromResult(
                 new Model(
                     Guid.NewGuid()
-                        .ToString(), 86400, "Bearer"));
+                        .ToString(), 86400, "Bearer", "read, write, update, delete"));
         }
     }
 }

--- a/app/Kwality.UVault/Kwality.UVault.csproj
+++ b/app/Kwality.UVault/Kwality.UVault.csproj
@@ -9,7 +9,7 @@
   <!-- NuGet (Package) information. -->
   <PropertyGroup>
     <PackageId>Kwality.UVault</PackageId>
-    <Version>2.7.0</Version>
+    <Version>2.8.0</Version>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/dotnet-essentials/Kwality.UVault</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/app/Kwality.UVault/M2M/Internal/Stores/Static.Token.Store{TToken}.cs
+++ b/app/Kwality.UVault/M2M/Internal/Stores/Static.Token.Store{TToken}.cs
@@ -37,6 +37,7 @@ internal sealed class StaticTokenStore<TToken> : IApplicationTokenStore<TToken>
             Token = GenerateToken(),
             ExpiresIn = 86400,
             TokenType = "Bearer",
+            Scope = string.Empty,
         };
 
         return Task.FromResult(token);

--- a/app/Kwality.UVault/M2M/Models/Application.Token.Model.cs
+++ b/app/Kwality.UVault/M2M/Models/Application.Token.Model.cs
@@ -33,14 +33,16 @@ public class TokenModel
     {
     }
 
-    public TokenModel(string token, int expiresIn, string tokenType)
+    public TokenModel(string token, int expiresIn, string tokenType, string scope)
     {
         this.Token = token;
         this.ExpiresIn = expiresIn;
         this.TokenType = tokenType;
+        this.Scope = scope;
     }
 
     public string? Token { get; init; }
     public int ExpiresIn { get; init; }
     public string? TokenType { get; init; }
+    public string? Scope { get; init; }
 }


### PR DESCRIPTION
# Description

- Add the `scope` field when requesting a M2M token.

## Fixes

Fixes #29 

## Type of change

<!-- Please tick the appropriate boxes. -->

- [x] New feature (non-breaking change which adds functionality).
- [ ] This change contains documentation update(s).
